### PR TITLE
Fix typos in comments

### DIFF
--- a/src/pyFVM/Coefficients.py
+++ b/src/pyFVM/Coefficients.py
@@ -59,7 +59,7 @@ class Coefficients():
     #     """
     #     if len(kwargs)==0:
             
-        ## (list of lists) identical to polyMesh.elementNeighbours. Provides a list where each index represents an element in the domain. Each index has an associated list which contains the elements for which is shares a face (i.e. the neighouring elements).
+        ## (list of lists) identical to polyMesh.elementNeighbours. Provides a list where each index represents an element in the domain. Each index has an associated list which contains the elements for which is shares a face (i.e. the neighbouring elements).
         self.theCConn = Region.mesh.elementNeighbours
         
         ## array containing the number of neighbouring elements for each element in the domain

--- a/src/pyFVM/Polymesh.py
+++ b/src/pyFVM/Polymesh.py
@@ -643,7 +643,7 @@ class Polymesh():
         这个方法是CFD网格处理的关键步骤，为模拟提供了网格单元格之间的拓扑信息，这对于求解流体动力学方程和网格通信是必要的。
 
         """
-        ## (list of lists) List where each index represents an element in the domain. Each index has an associated list which contains the elements for which is shares a face (i.e. the neighouring elements). Do not confuse a faces 'neighbour cell', which refers to a face's neighbour element, with the neighbouring elements of a cell. 
+        ## (list of lists) List where each index represents an element in the domain. Each index has an associated list which contains the elements for which is shares a face (i.e. the neighbouring elements). Do not confuse a faces 'neighbour cell', which refers to a face's neighbour element, with the neighbouring elements of a cell.
         # self.elementNeighbours = [[] for _ in range(0,self.numberOfElements)]
         self.elementNeighbours = np.empty(self.numberOfElements, dtype=object)
 


### PR DESCRIPTION
## Summary
- correct spelling of "neighbouring" in comments

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'scipy')*

------
https://chatgpt.com/codex/tasks/task_e_684a70004a948331bf9fa92bcc8b56a4